### PR TITLE
fix: getTransactionReceiptsByBlock api

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -669,7 +669,7 @@ func (s *PublicBlockChainAPI) GetTransactionReceiptsByBlock(ctx context.Context,
 		if receipt.Logs == nil {
 			fields["logs"] = [][]*types.Log{}
 		}
-		if borReceipt != nil {
+		if borReceipt != nil && idx == len(receipts)-1 {
 			fields["transactionHash"] = txHash
 		}
 		// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation


### PR DESCRIPTION
* What does the PR do?
This PR solves an api error, which gives wrong transactionHash in some condition.

* How to reproduce such error: 
if  a block contains a bor transaction, all of the transactions' txHash in this block will be same.
`curl --location --request POST https://rpc.bt.io --header 'Content-Type: application/json' --data-raw '{"jsonrpc":"2.0","method":"eth_getTransactionReceiptsByBlock","params":["0x8c6b00"],"id":199}'`

* How to fix this error:
If a block contains a bor transaction, this transaction is always appended to the last. Add extra check condition to prevent transactionHash to be overwritten.
