### PR TITLE
Fix Memory Leak

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -669,7 +669,7 @@ func (s *PublicBlockChainAPI) GetTransactionReceiptsByBlock(ctx context.Context,
 		if receipt.Logs == nil {
 			fields["logs"] = [][]*types.Log{}
 		}
-		if borReceipt != nil {
+		if borReceipt != nil && idx == len(receipts)-1 {
 			fields["transactionHash"] = txHash
 		}
 		// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation


### PR DESCRIPTION
This PR force calls Reheap periodically on the txpool to evict old transactions from the priced list when London fork is not enabled. Otherwise, it calls setBaseFee that internally calls Reheap.